### PR TITLE
Added extra options and fixed error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+# Folders to ignore
+.vscode
+
+# Files to ignore
 *.swp

--- a/README.md
+++ b/README.md
@@ -1,22 +1,21 @@
 # tmux-notify
 
-Tmux plugin to notify you when processes complete. 
+Tmux plugin to notify you when processes complete.
 
 Notification is via libnotify and visual bell raised in the tmux window. Visual bells can be mapped (in the terminal level) to X11 urgency bit and handled by your window manager.
 
 ## Use cases
 
-+ When you have already started a process in a pane and wish to be notified; that is can't use a manual trigger
-+ Working in different containers (Docker) -> can't choose the shell -> and can't use a shell level feature
-+ Working over ssh but your tmux is on client side
+-   When you have already started a process in a pane and wish to be notified; that is can't use a manual trigger
+-   Working in different containers (Docker) -> can't choose the shell -> and can't use a shell level feature
+-   Working over ssh but your tmux is on client side
 
 ## Install
 
 Using [Tmux Plugin Manager](https://github.com/tmux-plugins/tpm), add:
 
-```
-set -g @plugin 'ChanderG/tmux-notify'
-```
+    set -g @plugin 'ChanderG/tmux-notify'
+
 to your `.tmux.conf`.
 
 Use `prefix + I` to install.
@@ -30,6 +29,35 @@ Use `prefix + I` to install.
 
 bash, notify-send on the machine with the tmux server.
 Tested only on Linux.
+
+## Configuration
+
+### Enable verbose notification
+
+By default, the notification text is set to `Tmux pane task completed!`. We have also included a verbose output option. When enabled information about the pane, window and session in which the task has completed is given.
+
+Put `set -g @tnotify-verbose 'on'` in `.tmux.conf` to enable this.
+
+#### Change the verbose notification message
+
+To change the verbose notifaction text put `set -g @tnotify-verbose-msg 'put your notification text here'` in `.tmux.conf`. You can use all the tmux variables in your notification text. Some useful tmux aliases are:
+
+-   `#D`: Pane id
+-   `#P`: Pane index
+-   `#T`: Pane title
+-   `#S`: Session name
+-   `#I`: Window index
+-   `#W`: Window name
+
+For the full list of aliases and variables you are refered to the `FORMATS`  section of the [tmux manual](http://man7.org/linux/man-pages/man1/tmux.1.html).
+
+### Change monitor update period
+
+By default, the monitor sleep period is set to 10 seconds. This means that tmux-notify checks the pane activity every 10 seconds.
+
+Put `set -g @tnotify-sleep-duration 'desired duration'` in `.tmux.conf` to change this duration.
+
+**NOTE:** Keep in mind that there is a trade-off between notification speed (short sleep duration) and the amount of memory this tool needs.
 
 ## How does it work?
 

--- a/scripts/cancel.sh
+++ b/scripts/cancel.sh
@@ -4,9 +4,17 @@
 PANEID=$(tmux list-panes | grep "active" | awk -F\] '{print $3}' | awk '{print $1}')
 PID_DIR=~/.tmux/notify
 
+# Cancel monitor process if active
+{ # Try
+
 # consult pid file for the pid
 PID=$(cat "$PID_DIR/$PANEID".pid)
-kill $PID
 
-# job done - remove pid file
+# job done - kill process and remove pid file
+kill $PID
 rm "$PID_DIR/$PANEID".pid
+
+} || { # Catch
+  tmux display-message "Pane not monitored..."
+  exit 0
+}

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -1,0 +1,20 @@
+# Helper functions
+
+# Get tmux option
+get_tmux_option() {
+	local option="$1"
+	local default_value="$2"
+	local option_value=$(tmux show-option -gqv "$option")
+	if [ -z "$option_value" ]; then
+		echo "$default_value"
+	else
+		echo "$option_value"
+	fi
+}
+
+# Set tmux option
+set_tmux_option() {
+	local option="$1"
+	local value="$2"
+	tmux set-option -gq "$option" "$value"
+}

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 
-# get id of the current active pane
-PANEID=$(tmux list-panes | grep "active" | awk -F\] '{print $3}' | awk '{print $1}')
-PID_DIR=~/.tmux/notify
+# Get current directory
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# write pid to file
-echo "$$" > "$PID_DIR/$PANEID".pid
+# Source helpers and variables
+source "$CURRENT_DIR/helpers.sh"
+source "$CURRENT_DIR/variables.sh"
 
-tmux display-message "Montoring pane..."
+## Functions
 
-# if user cancels 
+# if user cancels
 on_cancel()
 {
   tmux display-message "Cancelling monitoring..."
@@ -17,18 +17,46 @@ on_cancel()
 }
 trap 'on_cancel' TERM
 
+# Check if verbose option is enabled
+verbose_enabled() {
+	local verbose_value="$(get_tmux_option "$verbose_option" "$verbose_default")"
+	[ "$verbose_value" != "on" ]
+}
+
+## Main script
+
+# get id of the current active pane
+PANEID=$(tmux list-panes | grep "active" | awk -F\] '{print $3}' | awk '{print $1}')
+PID_DIR=~/.tmux/notify
+
+# write pid to file
+echo "$$" > "$PID_DIR/$PANEID".pid
+
+# Display tnotify start messsage
+tmux display-message "Montoring pane..."
+
+# Construct finish message
+if verbose_enabled; then # If @tnotify-verbose is disabled
+  complete_message="Tmux pane task completed!"
+else # If @tnotify-verbose is enabled
+  verbose_msg_value="$(get_tmux_option "$verbose_msg_option" "$verbose_msg_default")"
+  complete_message=$(tmux display-message -p "$verbose_msg_value")
+fi
+
+# Check process status every 10 seconds
 while true; do
+
   # capture pane output
   output=$(tmux capture-pane -pt $PANEID)
+
   # run tests to determine if work is done
   # if so, break and notify
   lc=$(echo $output | tail -c2)
-
   case $lc in
   "$" | "#" )
     # notify-send does not always work due to changing dbus params
     # see https://superuser.com/questions/1118878/using-notify-send-in-a-tmux-session-shows-error-no-notification#1118896
-    notify-send "Tmux pane task completed!"
+    notify-send "$complete_message"
     # trigger visual bell
     # your terminal emulator can be setup to set URGENT bit on visual bell
     # for eg, Xresources -> URxvt.urgentOnBell: true
@@ -36,7 +64,9 @@ while true; do
     break
   esac
 
-  sleep 10
+  # Sleep for a given time
+  monitor_sleep_duration_value=$(get_tmux_option "$monitor_sleep_duration" "$monitor_sleep_duration_default")
+  sleep $monitor_sleep_duration_value
 done
 
 # job done - remove pid file

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -1,0 +1,13 @@
+SUPPORTED_VERSION="1.9"
+
+## Tnotify tmux options
+
+# Notification verbosity settings
+verbose_option="@tnotify-verbose"
+verbose_default="off"
+verbose_msg_option="@tnotify-verbose-msg"
+verbose_msg_default="(#S, #I:#P) Tmux pane task completed!"
+
+# Monitor checker interval
+monitor_sleep_duration="@tnotify-sleep-duration"
+monitor_sleep_duration_default=10

--- a/tnotify.tmux
+++ b/tnotify.tmux
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# Initialize variables
+source "$CURRENT_DIR/scripts/helpers.sh"
+source "$CURRENT_DIR/scripts/variables.sh"
+
+# Get current directory
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PID_DIR=~/.tmux/notify
 
@@ -8,8 +13,8 @@ if [[ ! -d $PID_DIR ]]; then
   mkdir $PID_DIR
 fi
 
+# Bind plugin keys
 tmux unbind-key m
 tmux unbind-key M
-
-tmux bind-key m run-shell -b "$CURRENT_DIR/scripts/notify.sh" 
-tmux bind-key M run-shell -b "$CURRENT_DIR/scripts/cancel.sh" 
+tmux bind-key m run-shell -b "$CURRENT_DIR/scripts/notify.sh"
+tmux bind-key M run-shell -b "$CURRENT_DIR/scripts/cancel.sh"


### PR DESCRIPTION
= Fixes =
When trying to cancel a monitor session without first having cancelled
one I got a bash error message. I solved this by catching the error in
the `cancel.sh` script.

= New features =
I added 3 new features to the t-notify plugin.
- Ability to enable a verbose notification message
- Ability to set the verbose notification message
- Ability to change the monitor sleep duration.