### PR TITLE
Improves method of getting unique target ID's

### DIFF
--- a/scripts/cancel.sh
+++ b/scripts/cancel.sh
@@ -9,13 +9,6 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$CURRENT_DIR/helpers.sh"
 source "$CURRENT_DIR/variables.sh"
 
-# Get pane id
-SESSION_NR=$(tmux list-sessions | grep "(attached)" | awk '{print $1}' | tr -d :)
-WINDOW_NR=$(tmux list-windows | grep "(active)" | awk '{print $1}' | tr -d :)
-PANE_NR=$(tmux list-panes | grep "active" | awk -F\] '{print $3}' | awk '{print $1}' | tr -d %)
-PANE_ID=$(detox_file_name "s_${SESSION_NR}_w${WINDOW_NR}_p${PANE_NR}")
-PID_FILE_PATH="${PID_DIR}/${PANE_ID}.pid"
-
 # Cancel pane monitoring if active
 if [[ -f "$PID_FILE_PATH" ]]; then
 

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -20,10 +20,3 @@ set_tmux_option() {
 	local value="$2"
 	tmux set-option -gq "$option" "$value"
 }
-
-## Detox file names
-# Makes sure invalid chars are removed from a filename
-detox_file_name(){
-	local file_name="$1"
-	echo "${file_name//[^A-Za-z0-9._-]/_}"
-}

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -32,13 +32,6 @@ verbose_enabled() {
 
 ## Main script
 
-# Get pane id
-SESSION_NR=$(tmux list-sessions | grep "(attached)" | awk '{print $1}' | tr -d :)
-WINDOW_NR=$(tmux list-windows | grep "(active)" | awk '{print $1}' | tr -d :)
-PANE_NR=$(tmux list-panes | grep "active" | awk '{print $1}' | tr -d :)
-PANE_ID=$(detox_file_name "s_${SESSION_NR}_w${WINDOW_NR}_p${PANE_NR//%}")
-PID_FILE_PATH="${PID_DIR}/${PANE_ID}.pid"
-
 # Monitor pane if it is not already monitored
 if [[ ! -f "$PID_FILE_PATH" ]]; then  # If pane not yet monitored
 
@@ -60,7 +53,7 @@ if [[ ! -f "$PID_FILE_PATH" ]]; then  # If pane not yet monitored
   while true; do
 
     # capture pane output
-    output=$(tmux capture-pane -pt "$PANE_NR")
+    output=$(tmux capture-pane -pt %"$PANE_ID")
 
     # run tests to determine if work is done
     # if so, break and notify
@@ -69,9 +62,9 @@ if [[ ! -f "$PID_FILE_PATH" ]]; then  # If pane not yet monitored
     "$" | "#" )
       # tmux display-message "$@"
       if [[ "$1" == "refocus" ]]; then
-        tmux switch -t "$SESSION_NR"
-        tmux select-window -t "$WINDOW_NR"
-        tmux select-pane -t "$PANE_NR"
+        tmux switch -t \$"$SESSION_ID"
+        tmux select-window -t @"$WINDOW_ID"
+        tmux select-pane -t %"$PANE_ID"
       fi
       # notify-send does not always work due to changing dbus params
       # see https://superuser.com/questions/1118878/using-notify-send-in-a-tmux-session-shows-error-no-notification#1118896

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -5,6 +5,12 @@
 export SUPPORTED_VERSION="1.9"
 export PID_DIR=~/.tmux/notify
 
+# Get ID's
+export SESSION_ID=$(tmux display-message -p '#{session_id}'  | tr -d $)
+export WINDOW_ID=$(tmux display-message -p '#{session_id}' | tr -d @)
+export PANE_ID=$(tmux display-message -p '#{pane_id}' | tr -d %)
+export PID_FILE_PATH="${PID_DIR}/${PANE_ID}.pid"
+
 ## Tnotify tmux options
 
 # Notification verbosity settings

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -7,7 +7,7 @@ export PID_DIR=~/.tmux/notify
 
 # Get ID's
 export SESSION_ID=$(tmux display-message -p '#{session_id}'  | tr -d $)
-export WINDOW_ID=$(tmux display-message -p '#{session_id}' | tr -d @)
+export WINDOW_ID=$(tmux display-message -p '#{window_id}' | tr -d @)
 export PANE_ID=$(tmux display-message -p '#{pane_id}' | tr -d %)
 export PID_FILE_PATH="${PID_DIR}/${PANE_ID}.pid"
 


### PR DESCRIPTION
The window, session and pane ID's now directly correspond to the unique
ID's provided by tmux itself.  This also removes the detox_file_name()
helper function as the PID filename is now simply the numeric pane ID
which does not need sanitizing.

This fixes bugs #19 and #20.