### PR TITLE
Add macOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,12 @@ Use `prefix + I` to install.
 
 ## Pre-requisites
 
-notify-send or osascript on the machine with the tmux server.
+- Bash
+- Tmux
+- `notify-send` or `osascript`.
 
-Works on Linux and macOS (note: only actively tested on Linux).
+> **Note**
+>  Works on Linux and macOS (note: only actively tested on Linux).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ Use `prefix + I` to install.
 
 ## Pre-requisites
 
-bash, notify-send on the machine with the tmux server.
-Tested only on Linux.
+notify-send or osascript on the machine with the tmux server.
+
+Works on Linux and macOS (note: only actively tested on Linux).
 
 ## Configuration
 

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -10,18 +10,15 @@ source "$CURRENT_DIR/variables.sh"
 
 ## Functions
 
+# Send notification
 notify() {
-  # Try multiple notification systems
-  # Linux (notify-send)
-  if command -v notify-send &>/dev/null
-  then
+  # Switch notification method based on OS
+  if [[ "$OSTYPE" =~ ^darwin ]]; then # If macOS
+    osascript -e 'display notification "'"$1"'" with title "tmux-notify"'
+  else
     # notify-send does not always work due to changing dbus params
     # see https://superuser.com/questions/1118878/using-notify-send-in-a-tmux-session-shows-error-no-notification#1118896
     notify-send "$1"
-  # macOS (osascript)
-  elif command -v osascript &>/dev/null
-  then
-    osascript -e 'display notification "'"$1"'" with title "tmux-notify"'
   fi
 
   # trigger visual bell
@@ -30,6 +27,7 @@ notify() {
   tmux split-window "echo -e \"\a\" && exit"
 }
 
+# Handle cancelation of monitor job
 on_cancel()
 {
   # Wait a bit for all pane monitors to complete

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -10,6 +10,26 @@ source "$CURRENT_DIR/variables.sh"
 
 ## Functions
 
+notify() {
+  # Try multiple notification systems
+  # Linux (notify-send)
+  if command -v notify-send &>/dev/null
+  then
+    # notify-send does not always work due to changing dbus params
+    # see https://superuser.com/questions/1118878/using-notify-send-in-a-tmux-session-shows-error-no-notification#1118896
+    notify-send "$1"
+  # macOS (osascript)
+  elif command -v osascript &>/dev/null
+  then
+    osascript -e 'display notification "'"$1"'" with title "tmux-notify"'
+  fi
+
+  # trigger visual bell
+  # your terminal emulator can be setup to set URGENT bit on visual bell
+  # for eg, Xresources -> URxvt.urgentOnBell: true
+  tmux split-window "echo -e \"\a\" && exit"
+}
+
 on_cancel()
 {
   # Wait a bit for all pane monitors to complete
@@ -66,13 +86,7 @@ if [[ ! -f "$PID_FILE_PATH" ]]; then  # If pane not yet monitored
         tmux select-window -t @"$WINDOW_ID"
         tmux select-pane -t %"$PANE_ID"
       fi
-      # notify-send does not always work due to changing dbus params
-      # see https://superuser.com/questions/1118878/using-notify-send-in-a-tmux-session-shows-error-no-notification#1118896
-      notify-send "$complete_message"
-      # trigger visual bell
-      # your terminal emulator can be setup to set URGENT bit on visual bell
-      # for eg, Xresources -> URxvt.urgentOnBell: true
-      tmux split-window "echo -e \"\a\" && exit"
+      notify "$complete_message"
       break
     esac
 


### PR DESCRIPTION
It's a neat little tool that I'd like to use on my work Macbook too, so I wrote this small patch.

If notify-send exists, use it. Otherwise, if osascript (Apple's built-in scripting language) exists, use that.

I edited the README to state "only actively tested on Linux" as I assumed you wanted to not create the assumption of actively maintaining macOS support.