### PR TITLE
Change $PID_DIR to $XDG_STATE_HOME/tmux/tmux-notify

### DIFF
--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -39,7 +39,7 @@ if [[ ! -f "$PID_FILE_PATH" ]]; then  # If pane not yet monitored
   echo "$$" > "$PID_FILE_PATH"
 
   # Display tnotify start messsage
-  tmux display-message "Montoring pane..."
+  tmux display-message "Monitoring pane..."
 
   # Construct tnotify finish message
   if verbose_enabled; then  # If @tnotify-verbose is disabled

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -3,7 +3,7 @@
 
 ## Main variables
 export SUPPORTED_VERSION="1.9"
-export PID_DIR=~/.tmux/notify
+export PID_DIR="$XDG_STATE_HOME/tmux/tmux-notify"
 
 # Get ID's
 export SESSION_ID=$(tmux display-message -p '#{session_id}'  | tr -d $)

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -2,8 +2,11 @@
 ## -- Add tmux plugin variables
 
 ## Main variables
-export SUPPORTED_VERSION="1.9"
-export PID_DIR="$XDG_STATE_HOME/tmux/tmux-notify"
+if [[ -z $XDG_STATE_HOME ]]; then
+    export PID_DIR=~/.tmux/notify
+else
+    export PID_DIR="$XDG_STATE_HOME/tmux/tmux-notify"
+fi
 
 # Get ID's
 export SESSION_ID=$(tmux display-message -p '#{session_id}'  | tr -d $)

--- a/tnotify.tmux
+++ b/tnotify.tmux
@@ -2,7 +2,7 @@
 
 # Get current directory
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-PID_DIR=~/.tmux/notify
+PID_DIR="$XDG_CACHE_HOME/tmux/tmux-notify"
 
 # Initialize variables
 source "$CURRENT_DIR/scripts/helpers.sh"

--- a/tnotify.tmux
+++ b/tnotify.tmux
@@ -2,7 +2,13 @@
 
 # Get current directory
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-PID_DIR="$XDG_CACHE_HOME/tmux/tmux-notify"
+
+# Set PID_DIR
+if [[ -z $XDG_CACHE_HOME ]]; then
+    export PID_DIR=~/.tmux/notify
+else
+    export PID_DIR="$XDG_CACHE_HOME/tmux/tmux-notify"
+fi
 
 # Initialize variables
 source "$CURRENT_DIR/scripts/helpers.sh"


### PR DESCRIPTION
I suspect there's a reason why this hasn't been before, but I just wanted to unclutter my home directory. tmux has supported XDG base directories since 3.2, so this simply changes the location of `$PID_DIR` to `$XDG_STATE_HOME/tmux/tmux-notify`