### PR TITLE
docs: add not maintained warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # tmux-notify
 
-[![Maintained](https://img.shields.io/badge/Maintained%3F-yes-green)](https://github.com/ChanderG/tmux-notify/pulse)
+[![Maintained](https://img.shields.io/badge/Maintained%3F-no-red)](https://github.com/ChanderG/tmux-notify/pulse)
 [![Contributions](https://img.shields.io/badge/contributions-welcome-orange.svg)](contributing.md)
 [![Tmux version](https://img.shields.io/badge/tmux-%3D%3E1.9-blue)](https://github.com/tmux/tmux/wiki)
+
+> **Warning**
+> This project appears to be no longer maintained by the original author. The newly maintained version of this project can be found at [rickstaa/tmux-notify](https://github.com/rickstaa/tmux-notify).
 
 <a href="https://github.com/ChanderG/tmux-notify"><img src="resources/tmux-notify-logo.svg" alt="tmux notify logo" width="567" height="135"/></a>
 

--- a/tnotify.tmux
+++ b/tnotify.tmux
@@ -31,3 +31,13 @@ tmux bind-key M run-shell -b "$CURRENT_DIR/scripts/cancel.sh"
 tmux bind-key M-m run-shell -b "$CURRENT_DIR/scripts/notify.sh true"
 tmux bind-key C-m run-shell -b "$CURRENT_DIR/scripts/notify.sh false true"
 tmux bind-key C-M-m run-shell -b "$CURRENT_DIR/scripts/notify.sh true true"
+
+# Print deprecated message
+deprication_warning="'ChanderG/tmux-notify' is no longer maintained. Please switch to 'rickstaa/tmux-notify'."
+if [[ "$OSTYPE" =~ ^darwin ]]; then # If macOS
+  osascript -e 'display notification "'"$deprication_warning"'" with title "tmux-notify"'
+else
+  # notify-send does not always work due to changing dbus params
+  # see https://superuser.com/questions/1118878/using-notify-send-in-a-tmux-session-shows-error-no-notification#1118896
+  notify-send "WARNING" "${deprication_warning}"
+fi


### PR DESCRIPTION
This pull requests adds a deprecation warning, since the original author no longer maintains the repository(see https://github.com/ChanderG/tmux-notify/issues/28). The newly maintained version of this project can be found at https://github.com/rickstaa/tmux-notify.
