### PR TITLE
feat: make visual bell an option `@tnotify-visual-bell`, as the default command isn't compatible with *Nushell*

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -116,5 +116,8 @@ notify() {
   # trigger visual bell
   # your terminal emulator can be setup to set URGENT bit on visual bell
   # for eg, Xresources -> URxvt.urgentOnBell: true
-  tmux split-window -t "\$$SESSION_ID":@"$WINDOW_ID" "echo -e \"\a\" && exit"
+  local visual_bell="$(get_tmux_option "$tmux_notify_visual_bell" "$tmux_notify_visual_bell_default")"
+  if [ "$visual_bell" == "on" ]; then
+    tmux split-window -t "\$$SESSION_ID":@"$WINDOW_ID" "echo -e \"\a\" && exit"
+  fi
 }

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -32,6 +32,10 @@ export verbose_title_default=""
 export monitor_sleep_duration="@tnotify-sleep-duration"
 export monitor_sleep_duration_default=10
 
+# Visual bell notification settings
+export tmux_notify_visual_bell="@tnotify-visual-bell"
+export tmux_notify_visual_bell_default="on"
+
 # Telegram notification settings
 export tmux_notify_telegram_bot_id="@tnotify-telegram-bot-id"
 export tmux_notify_telegram_channel_id="@tnotify-telegram-channel-id"


### PR DESCRIPTION
The option name is from <https://github.com/rickstaa/tmux-notify/pull/53#issuecomment-1762816512>.

Not in the PR, but also on my system, the default command clears the bottom line. I use *Ghostty* and *Nushell*. In *Nushell*, this is required in the script instead (not included in the PR):

```sh
tmux split-window -h -t "\$$SESSION_ID":@"$WINDOW_ID" "print \"\\a\"; exit"
```

To have *Nushell* show a bell with this PR, turn this off and use a custom command:

```tmux
set-option -g @tnotify-visual-bell "off"
set-option -g @tnotify-custom-cmd 'tmux split-window -h "print \"\a\""'
```